### PR TITLE
Run update-dependencies at 9pm on Friday instead of midnight on Saturday

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,7 +1,7 @@
 name: Update Dependencies
 on:
   schedule:
-  - cron: 0 0 * * 6
+  - cron: 0 21 * * 5
 
 permissions:
   contents: write


### PR DESCRIPTION
This is closer to the time I actually start working on personal projects at night, and so it's more convenient to have the pull request there before I start working on projects at night rather than midway through at midnight.