### PR TITLE
Add create-local-package script to generate local copy of package for…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write --parser typescript 'src/**/*.{ts,tsx}' && eslint --fix --suppress-all 'src/**/*.{ts,tsx}' && rm -f eslint-suppressions.json",
     "lint": "tsc --noEmit && eslint 'src/**/*.{ts,tsx}' && prettier --check --parser typescript 'src/**/*.{ts,tsx}'",
     "build": "tsc && vite build",
+    "create-local-package": "rm -f alextheman-components-*.tgz && npm pack",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",


### PR DESCRIPTION
… development

This is a better approach than just installing the actual components folder directly, since we get a properly packaged version with all dependencies properly resolved to use in development. Installing the folder directly tends to link the entire package repository to node_modules, which is not quite what we want. We only want package.json and dist to appear in node_modules. This approach of generating a .tgz file and installing that ensures this.