### PR TITLE
Clean up Vite config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alextheman/components",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alextheman/components",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "ISC",
       "dependencies": {
         "@alextheman/utility": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/components",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "A package containing common React components used across my projects",
   "license": "ISC",
   "author": "alextheman",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,19 +25,19 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: "./src/index.ts", // Specifies the entry point for building the library.
-      name: "vite-react-ts-button", // Sets the name of the generated library.
-      fileName: (format) => `index.${format}.js`, // Generates the output file name based on the format.
-      formats: ["cjs", "es"], // Specifies the output formats (CommonJS and ES modules).
+      entry: "./src/index.ts",
+      name: "@alextheman/components",
+      fileName: (format) => `index.${format}.js`,
+      formats: ["cjs", "es"],
     },
     rollupOptions: {
-      external: [...Object.keys(peerDependencies)], // Defines external dependencies for Rollup bundling.
+      external: [...Object.keys(peerDependencies)],
     },
-    sourcemap: true, // Generates source maps for debugging.
-    emptyOutDir: true, // Clears the output directory before building.
+    sourcemap: true,
+    emptyOutDir: true,
     minify: "esbuild",
   },
-  plugins: [dts(), react()], // Uses the 'vite-plugin-dts' plugin for generating TypeScript declaration files (d.ts).
+  plugins: [dts(), react()],
   resolve: {
     alias: {
       src: path.resolve(__dirname, "src"),


### PR DESCRIPTION
There were a few unnecessary comments around that we did not need, so I got rid of them.

To be fair, though, we should probably be using tsup for the build process like I'm doing with all my other packages. That might need changing at some point.