### PR TITLE
Update GitHub Actions and use commit hash to specify versions rather …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   ci:
-    uses: AlexMan123456/github-actions/.github/workflows/ci.yml@v1.2.8
-    with:
-      run-tests: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: AlexMan123456/github-actions/npm-ci@388de78b445a39345f8fc5051d50a749cd0b1676 # v1.3.0
+        with:
+          run-tests: false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: AlexMan123456/github-actions/npm-publish@v1.2.7
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: AlexMan123456/github-actions/npm-publish@388de78b445a39345f8fc5051d50a749cd0b1676 # v1.3.0
         with:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: "npm"
@@ -49,7 +49,7 @@ jobs:
           rm -f package-lock-backup.json
         fi
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
       with:
         token: ${{ secrets.PAT_GITHUB }}
         branch: alex-up-bot/update-dependencies


### PR DESCRIPTION
…than tag

This plays better with npx actions-up, which we can use to automate these updates.